### PR TITLE
Some fixes for krazyworld

### DIFF
--- a/krazy_gridworld.py
+++ b/krazy_gridworld.py
@@ -363,7 +363,7 @@ class KrazyGridWorld:
         if self.simple_image_viewer is None:
             from gym.envs.classic_control.rendering import SimpleImageViewer
             self.simple_image_viewer = SimpleImageViewer()
-        im_obs = self.get_img_obs()
+        im_obs = self.get_img_obs(render_global_obs=True)
         self.simple_image_viewer.imshow(im_obs)
         time.sleep(0.075)
 
@@ -393,7 +393,9 @@ class KrazyGridWorld:
           grid_np = grid_np.flatten()
         return grid_np
 
-    def get_img_obs(self):
+    def get_img_obs(self, render_global_obs=None):
+        if render_global_obs is None:
+            render_global_obs = not self.use_local_obs
         grid_np = copy.deepcopy(self.game_grid.grid_np)
         grid_np[self.agent.agent_position[0], self.agent.agent_position[1]] = self.tile_types.agent
         fake_img = np.zeros((self.game_grid.grid_squares_per_row, self.game_grid.grid_squares_per_row, 3))
@@ -408,6 +410,8 @@ class KrazyGridWorld:
             neighbors = []
             x, y = self.agent.agent_position
             valid_idxs = np.zeros_like(fake_img)
+            if render_global_obs:
+              valid_idxs[:, :] = 0.5
             valid_idxs[x, y] = 1.0
             for _i, _j in [(-1, -1), (0, -1), (1, -1), (1, 0), (1, 1), (0, 1), (-1, 1), (-1, 0)]:
                 i, j = (_i + x, _j + y)
@@ -444,7 +448,7 @@ class KrazyGridWorld:
 
 def run_grid():
     kw = KrazyGridWorld(screen_height=256, grid_squares_per_row=10,
-                        one_hot_obs=False, use_local_obs=False, image_obs=True,
+                        one_hot_obs=False, use_local_obs=True, image_obs=True,
                         seed=42, task_seed=68,
                         num_goals=3, max_goal_distance=np.inf, min_goal_distance=2,
                         death_square_percentage=0.08,

--- a/krazy_gridworld.py
+++ b/krazy_gridworld.py
@@ -124,6 +124,12 @@ class GameGrid:
             self.reset_goal_squares()
             self.game_grid_init = copy.deepcopy(self.grid_np)
 
+        def get_one_normal_square(self):
+            g = self.task_rng.randint(0, self.grid_squares_per_row - 1, (2,))
+            if self.grid_np[g[0], g[1]] == self.tile_types.normal:
+                return g
+            return self.get_one_normal_square()
+
         def get_one_non_agent_square(self):
             g = self.task_rng.randint(0, self.grid_squares_per_row - 1, (2,))
             if g[0] != self.agent.agent_position[0] or g[1] != self.agent.agent_position[1]:
@@ -284,14 +290,14 @@ class KrazyGridWorld:
 
     def reset_task(self):
         # reset the entire board and agent start position, generating a new MDP.
-        self.agent.agent_position = (None, None)
+        self.agent.agent_position = (-1, -1)
         self.game_grid.get_new_game_grid()
         self.reset_agent_start_position()
 
     def reset_agent_start_position(self):
         # keep the previous board but update the agents starting position.
         # keeps the previous MDP but samples x_0.
-        new_start = self.game_grid.get_one_non_agent_square()
+        new_start = self.game_grid.get_one_normal_square()
         self.agent.agent_position = new_start
         self.agent.agent_position_init = new_start
 

--- a/krazy_gridworld.py
+++ b/krazy_gridworld.py
@@ -278,12 +278,13 @@ class KrazyGridWorld:
             self.agent.change_dynamics()
         if reset_board:
             self.reset_task()
-        if reset_agent_start_pos:
+        elif reset_agent_start_pos:
             self.reset_agent_start_position()
         return self.get_obs()
 
     def reset_task(self):
         # reset the entire board and agent start position, generating a new MDP.
+        self.agent.agent_position = (None, None)
         self.game_grid.get_new_game_grid()
         self.reset_agent_start_position()
 

--- a/krazy_gridworld.py
+++ b/krazy_gridworld.py
@@ -294,9 +294,10 @@ class KrazyGridWorld:
         if self.image_obs:
             return self.get_img_obs()
         else:
-            return None
+            return self.get_state_obs()
 
     def step(self, a, render=False):
+        start_reward = self.get_reward()
         if self.agent.dead is False:
             proposed_step = self.agent.try_step(a)
             if self.game_grid.is_position_legal(proposed_step):
@@ -324,7 +325,7 @@ class KrazyGridWorld:
 
             if render:
                 self.render()
-        return self.get_obs(), self.get_reward(), self.agent.dead, dict()
+        return self.get_obs(), self.get_reward() - start_reward, self.agent.dead, dict()
 
     def check_dead(self):
         agent_pos = self.agent.agent_position

--- a/krazy_gridworld.py
+++ b/krazy_gridworld.py
@@ -418,7 +418,7 @@ class KrazyGridWorld:
             fake_img *= valid_idxs
 
         res = cv2.resize(fake_img,
-                         dsize=(256, 256),
+                         dsize=self.screen_dim,
                          interpolation=cv2.INTER_NEAREST)
         res = res.astype(np.uint8)
         return res
@@ -437,7 +437,8 @@ class KrazyGridWorld:
             return rew
 
     def close(self):
-        self.simple_image_viewer.close()
+        if self.simple_image_viewer is not None:
+            self.simple_image_viewer.close()
 
 
 def run_grid():

--- a/krazy_gridworld.py
+++ b/krazy_gridworld.py
@@ -366,31 +366,31 @@ class KrazyGridWorld:
         self.simple_image_viewer.imshow(im_obs)
         time.sleep(0.075)
 
-    def get_state_obs(self):
+    def get_state_obs(self, flatten=True):
         grid_np = copy.deepcopy(self.game_grid.grid_np)
         agent_p = self.agent.agent_position
         grid_np[agent_p[0], agent_p[1]] = self.tile_types.agent
         grid_np = grid_np.astype(np.uint8)
         #agent_p = np.array(self.agent.agent_position)
         if self.one_hot_obs:
-            n_values = np.max(grid_np) + 1
+            n_values = len(self.tile_types.all_tt)
             grid_np = np.eye(n_values)[grid_np]
             #agent_p_temp = np.zeros((self.game_grid.grid_squares_per_row, self.game_grid.grid_squares_per_row, 1))
             #agent_p_temp[agent_p[0], agent_p[1], :] = 1
 
         if self.use_local_obs:
-            neighbors = []
             x, y = self.agent.agent_position
+            valid_idxs = np.zeros_like(grid_np)
+            valid_idxs[x, y] = 1.0
             for _i, _j in [(-1, -1), (0, -1), (1, -1), (1, 0), (1, 1), (0, 1), (-1, 1), (-1, 0)]:
                 i, j = (_i + x, _j + y)
                 if 0 <= i < self.game_grid.grid_squares_per_row and 0 <= j < self.game_grid.grid_squares_per_row:
-                    neighbors.append([j, i])
-                else:
-                    neighbors.append(None)
+                    valid_idxs[i, j] = 1.0
+            grid_np *= valid_idxs
 
-            grid_np = np.array(neighbors)
-
-        return grid_np.flatten()
+        if flatten:
+          grid_np = grid_np.flatten()
+        return grid_np
 
     def get_img_obs(self):
         grid_np = copy.deepcopy(self.game_grid.grid_np)

--- a/krazy_gridworld.py
+++ b/krazy_gridworld.py
@@ -36,8 +36,10 @@ class TileTypes:
             self.energy = 9
             self.all_tt = [self.hole, self.normal, self.goal, self.agent, self.transporter, self.door,
                            self.key, self.death, self.ice, self.energy]
-            self.colors = [Color.black, Color.white, Color.gold, Color.blue, Color.orange, Color.silver,
-                           Color.magenta, Color.red, Color.purple, Color.green]
+            self.initial_colors = [
+                Color.black, Color.white, Color.gold, Color.blue, Color.orange, Color.silver,
+                Color.magenta, Color.red, Color.purple, Color.green]
+            self.colors = list(self.initial_colors)
             self._rng = rng
 
         def switch_tile_type_values(self):
@@ -47,6 +49,7 @@ class TileTypes:
                 self.all_tt[i] = tt_idx
 
         def reset_colors(self):
+            self.colors = list(self.initial_colors)
             self._rng.shuffle(self.colors)
 
 
@@ -64,6 +67,7 @@ class Agent:
             self._rng = rng
 
         def change_dynamics(self):
+            self.dynamics = [0, 1, 2, 3]
             self._rng.shuffle(self.dynamics)
 
         def give_energy(self):


### PR DESCRIPTION
Hi Bradly, would you mind reviewing these fixes? And please let me know if you'd rather have these broken up into separate pull requests. The major changes are:

1. What I think is a bug fix for get_state_obs when use_local_obs is True.
2. Return per-step rewards rather than episode returns.

And then some minor changes:

1. Use np.random everywhere so you can easily set a task seed.
2. Remove the init_pos_seed argument (it wasn't used).
3. Use the screen_dim argument when rendering the observation.
4. Add an option to render the global board even when use_local_obs is True.
5. Add an option to return the state observation as a grid.
6. Keep the state observation sizes the same even when not all square types are present in the grid.
7. When not using image observations, return the state observation from step.
8. Don't crash when close() is called before render().
9. Make color and dynamics, and game_grid samples idempotent for a given rng.
10. Make agent position resets choose a random normal tile.